### PR TITLE
解决docker一键部署无法启动，缺少表config_info_gray

### DIFF
--- a/openapi-platform-backend/openapi-platform-web/sql/init.sql
+++ b/openapi-platform-backend/openapi-platform-web/sql/init.sql
@@ -127,7 +127,28 @@ create table if not exists openapi_platform.`invoke_info`
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/******************************************/
+/*   表名称 = config_info_gray             */
+/******************************************/
+CREATE TABLE config_info_gray (
+                                  id bigint NOT NULL AUTO_INCREMENT,
+                                  data_id varchar(255) NOT NULL,
+                                  group_id varchar(128) NOT NULL,
+                                  tenant_id varchar(128) default '',
+                                  gray_name varchar(128) NOT NULL,
+                                  gray_rule TEXT,
+                                  app_name varchar(128),
+                                  src_ip varchar(128),
+                                  src_user varchar(128) default '',
+                                  content TEXT,
+                                  md5 varchar(32) DEFAULT NULL,
+                                  encrypted_data_key varchar(32) DEFAULT NULL,
+                                  gmt_create timestamp NOT NULL DEFAULT '2010-05-05 00:00:00',
+                                  gmt_modified timestamp NOT NULL DEFAULT '2010-05-05 00:00:00',
+                                  constraint configinfogray_id_key PRIMARY KEY (id),
+                                  constraint uk_configinfogray_datagrouptenantgrayname UNIQUE (data_id,group_id,tenant_id,gray_name));
+CREATE INDEX config_info_gray_dataid_gmt_modified ON config_info_gray(data_id,gmt_modified);
+CREATE INDEX config_info_gray_gmt_modified ON config_info_gray(gmt_modified);
 /******************************************/
 /*   表名称 = config_info                  */
 /******************************************/


### PR DESCRIPTION
解决docker一键部署无法启动，缺少表config_info_gray